### PR TITLE
fix: typo in onSuccess template

### DIFF
--- a/src/templates/onSuccess.ejs
+++ b/src/templates/onSuccess.ejs
@@ -1,4 +1,4 @@
-<h1>Netlify build for site <%= SITE_NAME %> has been sucesfull.</h1>
+<h1>Netlify build for site <%= SITE_NAME %> has been successful.</h1>
 <p>
   Finished processing build request. Site <%= SITE_NAME %> is live ✨.
   <br />


### PR DESCRIPTION
Address a small typo in the `onSuccess` template 👍 